### PR TITLE
Add t.Dropped(); fix #11

### DIFF
--- a/multitick.go
+++ b/multitick.go
@@ -19,6 +19,7 @@ type Ticker struct {
 	ticker    *time.Ticker
 	stopCh    chan struct{}
 	stopped   bool
+	dropped   int
 }
 
 // NewTicker creates and starts a new Ticker, whose ticks are sent to
@@ -88,6 +89,11 @@ func (t *Ticker) Stop() {
 	t.stopped = true
 }
 
+// Dropped returns the number of dropped ticks.
+func (t *Ticker) Dropped() int {
+	return t.dropped
+}
+
 // This could be inlined as an anonymous function, but I think it's easier to
 // read stacktraces with real function names in them.
 func (t *Ticker) tick() {
@@ -99,6 +105,7 @@ func (t *Ticker) tick() {
 				select {
 				case t.chans[i] <- tick:
 				default:
+					t.dropped++
 				}
 			}
 			t.mux.Unlock()

--- a/multitick_test.go
+++ b/multitick_test.go
@@ -26,3 +26,14 @@ func TestTicker(t *testing.T) {
 		}
 	}
 }
+
+func TestDropped(t *testing.T) {
+	tick := NewTicker(time.Millisecond, 0)
+	tick.Subscribe()
+	time.Sleep(time.Second)
+	tick.Stop()
+	t.Log(tick.Dropped())
+	if tick.Dropped() < 800 {
+		t.Errorf("got %v dropped ticks, wanted at least 800", tick.Dropped())
+	}
+}


### PR DESCRIPTION
I considered adding a Stats type and a more general-purpose function, but could not think of anything else I would want to potentially instrument in the future. I could instrument the total number sent, but it doesn't seem useful. So I opted to keep it simple and direct. @ElPeque what do you think?
