### PR TITLE
Dropped tick stats

### DIFF
--- a/multitick.go
+++ b/multitick.go
@@ -91,8 +91,8 @@ func (t *Ticker) Stop() {
 
 // Dropped returns the number of dropped ticks.
 func (t *Ticker) Dropped() int {
-	t.tickerMux.Lock()
-	defer t.tickerMux.Unlock()
+	t.mux.Lock()
+	defer t.mux.Unlock()
 	return t.dropped
 }
 
@@ -107,9 +107,7 @@ func (t *Ticker) tick() {
 				select {
 				case t.chans[i] <- tick:
 				default:
-					t.tickerMux.Lock()
 					t.dropped++
-					t.tickerMux.Unlock()
 				}
 			}
 			t.mux.Unlock()


### PR DESCRIPTION
Add buffering on ticker channel & add mix locking around dropped-tick count to address "data race" test failures.
